### PR TITLE
Add support for Invite to Group API

### DIFF
--- a/lib/groups.js
+++ b/lib/groups.js
@@ -64,6 +64,30 @@ Groups.prototype.update = function(token, group){
 };
 
 /**
+ * Invite to Group
+ *
+ * A group administrator can invite users to join their group using the Invite
+ * to Group operation. This creates a new user invitation, which the users
+ * accept or decline. The role of the user and the invitation expiration date
+ * can be set in the invitation. A notification is created for the user
+ * indicating that they were invited to join the group. Available only to
+ * authenticated users.
+ */
+Groups.prototype.invite = function(token, groupId, users){
+  var dfd = Q.defer();
+  //community/groups/2ecb37a8c8fb4051af9c086c25503bb0/invite
+  var url = this.baseUrl + '/community/groups/' + groupId + '/invite?f=json&users=' + users + '&token=' + token;
+
+  var options = {
+    url: url,
+    method: "POST",
+	form: {id:groupId}
+  };
+  helper.post(options, dfd);
+  return dfd.promise;
+};
+
+/**
  * Create Group
  *
  * Only authenticated users can create groups. The user who creates the group 

--- a/test/groups.spec.js
+++ b/test/groups.spec.js
@@ -46,5 +46,20 @@ describe('community ', function () {
       }).done();
     });  
 
+    it("invite to group", function(done) {
+      var fakeGroup = {
+        "id": "123GROUPID456"
+      };
+      scope = nock(prodUrl)
+              .post('/sharing/rest/community/groups/123GROUPID456/invite?f=json&users=someuser&token=sometoken', fakeGroup)
+              .reply(200, fakeGroup);
+
+      ago.community.groups.invite('sometoken', fakeGroup.id, 'someuser')
+      .then(function(selfJson){
+        scope.done();
+        done();
+      }).done();
+    });
+
   });//groups
 });//community


### PR DESCRIPTION
Implements the following:
http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Invite_to_Group/02r30000006v000000/

This only supports the users parameter and excludes both role and expiration.
